### PR TITLE
chore: fix changeset ignore config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,7 +17,7 @@
     "useCalculatedVersionForSnapshots": true,
     "updateInternalDependencies": "patch"
   },
-  "ignore": ["docs"],
+  "ignore": [],
   "release": {
     "tag": "latest"
   }


### PR DESCRIPTION
## Summary
- remove nonexistent `docs` package from changesets ignore list

## Testing
- `pnpm changeset status`
- `pnpm changeset publish --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68907264d0388324b315b2f9aa611fb5