### PR TITLE
feat(core): extend theme colors with semantic virtualColor entries

### DIFF
--- a/libs/@core/core/src/components/colors/index.ts
+++ b/libs/@core/core/src/components/colors/index.ts
@@ -1,39 +1,10 @@
 import {
   type DefaultMantineColor,
   type MantineColorsTuple,
+  virtualColor,
 } from "@mantine/core";
 
-export enum THEME_NAME {
-  PRIMARY = "primary",
-}
-
-export type ThemeNameT =
-  | (DefaultMantineColor & "primary")
-  | "blueGray"
-  | "brown"
-  | "tomato"
-  | "deepOrange"
-  | "brightGreen"
-  | "green"
-  | "lightBlue"
-  | "skyBlue"
-  | "paleBlue"
-  | "brightBlue"
-  | "deepBlue"
-  | "paleIndigo"
-  | "purple"
-  | "palePurple"
-  | "paleViolet"
-  | "darkPink"
-  | "brightPink"
-  | "pink"
-  | "violet"
-  | "magenta"
-  | "paleRed"
-  | "deepRed"
-  | "yellow";
-
-export const THEME_COLORS: Partial<Record<ThemeNameT, MantineColorsTuple>> = {
+export const THEME_COLORS = {
   primary: [
     "#ffeaf3",
     "#fcd4e1",
@@ -322,4 +293,28 @@ export const THEME_COLORS: Partial<Record<ThemeNameT, MantineColorsTuple>> = {
     "#b41220",
     "#9e0419",
   ],
+  secondary: virtualColor({
+    name: "secondary",
+    light: "paleBlue",
+    dark: "deepBlue",
+  }),
+  info: virtualColor({ name: "info", light: "lightBlue", dark: "skyBlue" }),
+  success: virtualColor({ name: "success", light: "green", dark: "green" }),
+  warning: virtualColor({
+    name: "warning",
+    light: "yellow",
+    dark: "deepOrange",
+  }),
+  danger: virtualColor({ name: "danger", light: "deepRed", dark: "deepRed" }),
 };
+
+export type ThemeNameT = DefaultMantineColor | keyof typeof THEME_COLORS;
+
+export enum THEME_NAME {
+  PRIMARY = "primary",
+  SECONDARY = "secondary",
+  SUCCESS = "success",
+  WARNING = "warning",
+  INFO = "info",
+  DANGER = "danger",
+}


### PR DESCRIPTION
## Summary
- rework theme colors to add semantic names and Mantine `virtualColor`
- expose full theme name union and enum for primary/secondary/etc

## Testing
- `pnpm --filter @inexture/core lint` *(fails: No files matching the pattern '../base')*
- `pnpm --filter @inexture/core build` *(interrupted after repeated DTS build logs)*

------
https://chatgpt.com/codex/tasks/task_e_6890774bbab0832493685743ecf76a41