### PR TITLE
fix(core): re-export react icon packs with type hints

### DIFF
--- a/.changeset/bright-icons-hint.md
+++ b/.changeset/bright-icons-hint.md
@@ -1,0 +1,5 @@
+---
+"@inexture/core": patch
+---
+
+re-export React icon packs to improve TypeScript hints

--- a/libs/@core/core/src/icons/index.d.ts
+++ b/libs/@core/core/src/icons/index.d.ts
@@ -9,3 +9,35 @@ export {
     type IconTree,
     type IconType,
 } from "react-icons";
+
+export * as ai from "./ai";
+export * as bi from "./bi";
+export * as bs from "./bs";
+export * as cg from "./cg";
+export * as ci from "./ci";
+export * as di from "./di";
+export * as fa from "./fa";
+export * as fa6 from "./fa6";
+export * as fc from "./fc";
+export * as fi from "./fi";
+export * as gi from "./gi";
+export * as go from "./go";
+export * as gr from "./gr";
+export * as hi from "./hi";
+export * as hi2 from "./hi2";
+export * as im from "./im";
+export * as io from "./io";
+export * as io5 from "./io5";
+export * as lia from "./lia";
+export * as lu from "./lu";
+export * as md from "./md";
+export * as pi from "./pi";
+export * as ri from "./ri";
+export * as rx from "./rx";
+export * as si from "./si";
+export * as sl from "./sl";
+export * as tb from "./tb";
+export * as tfi from "./tfi";
+export * as ti from "./ti";
+export * as vsc from "./vsc";
+export * as wi from "./wi";

--- a/libs/@core/core/src/icons/index.ts
+++ b/libs/@core/core/src/icons/index.ts
@@ -9,3 +9,37 @@ export {
   type IconTree,
   type IconType,
 } from "react-icons";
+
+// Re-export individual icon packs for better type hints and DX
+export * as ai from "./ai";
+export * as bi from "./bi";
+export * as bs from "./bs";
+export * as cg from "./cg";
+export * as ci from "./ci";
+export * as di from "./di";
+export * as fa from "./fa";
+export * as fa6 from "./fa6";
+export * as fc from "./fc";
+export * as fi from "./fi";
+export * as gi from "./gi";
+export * as go from "./go";
+export * as gr from "./gr";
+export * as hi from "./hi";
+export * as hi2 from "./hi2";
+export * as im from "./im";
+export * as io from "./io";
+export * as io5 from "./io5";
+export * as lia from "./lia";
+export * as lu from "./lu";
+export * as md from "./md";
+export * as pi from "./pi";
+export * as ri from "./ri";
+export * as rx from "./rx";
+export * as si from "./si";
+export * as sl from "./sl";
+export * as tb from "./tb";
+export * as tfi from "./tfi";
+export * as ti from "./ti";
+export * as vsc from "./vsc";
+export * as wi from "./wi";
+


### PR DESCRIPTION
## Summary
- re-export react-icon packs from @inexture/core/icons for better DX
- add changeset for patch release

## Testing
- `pnpm -F @inexture/core lint` *(fails: No files matching the pattern "../base" were found)*
- `pnpm -F @inexture/core build` *(fails: Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68908169f0bc8324905c2223a830a9da