### PR TITLE
fix: expose Mantine exports

### DIFF
--- a/libs/@core/core/tsup.config.ts
+++ b/libs/@core/core/tsup.config.ts
@@ -12,7 +12,13 @@ const config: Options = {
   minifyIdentifiers: true,
   bundle: true,
   treeshake: false,
-  external: ["react", "react-dom"],
+  external: [
+    "react",
+    "react-dom",
+    "@mantine/core",
+    "@mantine/hooks",
+    "@mantine/modals",
+  ],
 };
 
 const iconDirs = fs


### PR DESCRIPTION
## Summary
- ensure Mantine packages remain external in core build so component re-exports work

## Testing
- `pnpm --filter @inexture/core build` *(fails: Command failed with signal "SIGTERM")*
- `pnpm --filter @inexture/core lint` *(fails: No files matching the pattern "../base" were found)*

------
https://chatgpt.com/codex/tasks/task_e_689090dbfb948324a1de280140d536a4