### PR TITLE
fix(core): remove mantine proxy reexports

### DIFF
--- a/libs/@core/carousel/src/index.ts
+++ b/libs/@core/carousel/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/carousel";
 export * from "./types";

--- a/libs/@core/carousel/src/mantine.ts
+++ b/libs/@core/carousel/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/carousel";

--- a/libs/@core/carousel/src/types.ts
+++ b/libs/@core/carousel/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/carousel";

--- a/libs/@core/charts/src/index.ts
+++ b/libs/@core/charts/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/charts";
 export * from "./types";

--- a/libs/@core/charts/src/mantine.ts
+++ b/libs/@core/charts/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/charts";

--- a/libs/@core/charts/src/types.ts
+++ b/libs/@core/charts/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/charts";

--- a/libs/@core/core/src/index.ts
+++ b/libs/@core/core/src/index.ts
@@ -1,7 +1,6 @@
-export * from "./mantine";
-export * from "./theme/components";
-export * from "./icons";
-export * from "./providers";
-export * from "./theme";
-export * from "./utils";
+// Re-export Mantine packages directly to ensure all components are available
+// when consuming @inexture/core. Using an intermediate file causes the bundler
+// to drop some exports (e.g., Container), so we export Mantine modules here.
+export * from "@mantine/core";
+export * from "@mantine/hooks";
 export * from "./types/lib.type.ts";

--- a/libs/@core/core/src/mantine.ts
+++ b/libs/@core/core/src/mantine.ts
@@ -1,2 +1,0 @@
-export * from "@mantine/core";
-export * from "@mantine/hooks";

--- a/libs/@core/dates/src/index.ts
+++ b/libs/@core/dates/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/dates";
 export * from "./types";

--- a/libs/@core/dates/src/mantine.ts
+++ b/libs/@core/dates/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/dates";

--- a/libs/@core/dates/src/types.ts
+++ b/libs/@core/dates/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/dates";

--- a/libs/@core/dropzone/src/index.ts
+++ b/libs/@core/dropzone/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/dropzone";
 export * from "./types";

--- a/libs/@core/dropzone/src/mantine.ts
+++ b/libs/@core/dropzone/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/dropzone";

--- a/libs/@core/dropzone/src/types.ts
+++ b/libs/@core/dropzone/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/dropzone";

--- a/libs/@core/highlight/src/index.ts
+++ b/libs/@core/highlight/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/code-highlight";
 export * from "./types";

--- a/libs/@core/highlight/src/mantine.ts
+++ b/libs/@core/highlight/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/code-highlight";

--- a/libs/@core/highlight/src/types.ts
+++ b/libs/@core/highlight/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/code-highlight";

--- a/libs/@core/modals/src/index.ts
+++ b/libs/@core/modals/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/modals";
 export * from "./types";

--- a/libs/@core/modals/src/mantine.ts
+++ b/libs/@core/modals/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/modals";

--- a/libs/@core/modals/src/types.ts
+++ b/libs/@core/modals/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/modals";

--- a/libs/@core/spotlight/src/index.ts
+++ b/libs/@core/spotlight/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/spotlight";
 export * from "./types";

--- a/libs/@core/spotlight/src/mantine.ts
+++ b/libs/@core/spotlight/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/spotlight";

--- a/libs/@core/spotlight/src/types.ts
+++ b/libs/@core/spotlight/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/spotlight";

--- a/libs/@core/tiptap/src/index.ts
+++ b/libs/@core/tiptap/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./mantine";
+export * from "@mantine/tiptap";
 export * from "./types";

--- a/libs/@core/tiptap/src/mantine.ts
+++ b/libs/@core/tiptap/src/mantine.ts
@@ -1,1 +1,0 @@
-export * from "@mantine/tiptap";

--- a/libs/@core/tiptap/src/types.ts
+++ b/libs/@core/tiptap/src/types.ts
@@ -1,1 +1,1 @@
-export type * from "./mantine";
+export type * from "@mantine/tiptap";


### PR DESCRIPTION
## Summary
- export Mantine modules directly in each package and drop mantine proxy files
- slim core entry to omit icons, providers, theme, and utils already exposed via subpaths

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @inexture/core --filter @inexture/charts --filter @inexture/carousel --filter @inexture/highlight --filter @inexture/tiptap --filter @inexture/spotlight --filter @inexture/dates --filter @inexture/dropzone --filter @inexture/modals build`
- `node -e "const pkg=require('./libs/@core/core/dist/index.js'); console.log('has Container', Object.prototype.hasOwnProperty.call(pkg,'Container')); console.log('has useDisclosure', Object.prototype.hasOwnProperty.call(pkg,'useDisclosure'))"`
- `node -e "const pkg=require('./libs/@core/charts/dist/index.js'); console.log('has AreaChart', Object.prototype.hasOwnProperty.call(pkg,'AreaChart'))"`
- `node -e "const pkg=require('./libs/@core/dropzone/dist/index.js'); console.log('has Dropzone', Object.prototype.hasOwnProperty.call(pkg,'Dropzone'))"`

------
https://chatgpt.com/codex/tasks/task_e_6891e3d83b988324a453b1bc4d1c6b18