### PR TITLE
test(core): add coverage

### DIFF
--- a/libs/@core/core/package.json
+++ b/libs/@core/core/package.json
@@ -59,7 +59,8 @@
     "build": "tsup && shx cp node_modules/@mantine/core/styles.layer.css dist/styles.layer.css && shx cp node_modules/@mantine/core/styles.css dist/styles.css && shx cp -r node_modules/@mantine/core/styles dist/",
     "dev": "tsup --watch",
     "lint": "eslint --fix ../base --ext .tsx,.jsx,.ts --max-warnings 0",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "test": "vitest run --coverage"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",

--- a/libs/@core/core/src/__tests__/index.test.ts
+++ b/libs/@core/core/src/__tests__/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { Button, useDisclosure } from '../index';
+import type { MantineRadius } from '../index';
+
+describe('core package', () => {
+  it('re-exports Mantine components, hooks, and types', () => {
+    const radius: MantineRadius = 'sm';
+    expect(radius).toBe('sm');
+    expect(Button).toBeDefined();
+    expect(useDisclosure).toBeDefined();
+  });
+});

--- a/libs/@core/core/vitest.config.ts
+++ b/libs/@core/core/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/__tests__/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      lines: 100,
+      functions: 100,
+      branches: 100,
+      statements: 100,
+      include: ['src/index.ts']
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest config and tests for core package

## Testing
- `pnpm test`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm build --filter @inexture/core`


------
https://chatgpt.com/codex/tasks/task_e_6891f61fc4688324b8b741e36cb2c8ed