### PR TITLE
chore: pin core peer dependency versions

### DIFF
--- a/.changeset/pin-core-peer-deps.md
+++ b/.changeset/pin-core-peer-deps.md
@@ -1,0 +1,13 @@
+---
+"@inexture/core": patch
+"@inexture/carousel": patch
+"@inexture/charts": patch
+"@inexture/dates": patch
+"@inexture/dropzone": patch
+"@inexture/highlight": patch
+"@inexture/modals": patch
+"@inexture/spotlight": patch
+"@inexture/tiptap": patch
+---
+
+Pin peer dependency versions instead of using "*".

--- a/libs/@core/carousel/package.json
+++ b/libs/@core/carousel/package.json
@@ -48,8 +48,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/charts/package.json
+++ b/libs/@core/charts/package.json
@@ -49,8 +49,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/core/package.json
+++ b/libs/@core/core/package.json
@@ -79,7 +79,7 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/dates/package.json
+++ b/libs/@core/dates/package.json
@@ -48,8 +48,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/dropzone/package.json
+++ b/libs/@core/dropzone/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/highlight/package.json
+++ b/libs/@core/highlight/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/modals/package.json
+++ b/libs/@core/modals/package.json
@@ -41,8 +41,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/spotlight/package.json
+++ b/libs/@core/spotlight/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/libs/@core/tiptap/package.json
+++ b/libs/@core/tiptap/package.json
@@ -92,8 +92,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "*",
-    "react": "*",
-    "react-dom": "*"
+    "@inexture/core": "^20.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin react and react-dom peer dependency versions to ^19.0.0 in @inexture/core
- pin @inexture/core, react, and react-dom peer dependency versions to specific ranges in all @inexture core packages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6892075fa1d08324abe759a7866a8dbe