### PR TITLE
chore: standardize internal dev dependency versions

### DIFF
--- a/libs/@core/carousel/package.json
+++ b/libs/@core/carousel/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/charts/package.json
+++ b/libs/@core/charts/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/dates/package.json
+++ b/libs/@core/dates/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/dropzone/package.json
+++ b/libs/@core/dropzone/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/highlight/package.json
+++ b/libs/@core/highlight/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "^24.2.0",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/modals/package.json
+++ b/libs/@core/modals/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "^24.2.0",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/spotlight/package.json
+++ b/libs/@core/spotlight/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@core/tiptap/package.json
+++ b/libs/@core/tiptap/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
+    "@inexture/core": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/libs/@library/form/package.json
+++ b/libs/@library/form/package.json
@@ -39,9 +39,9 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@inexture/core": "workspace:20.0.1",
-    "@inexture/dates": "workspace:22.0.1",
-    "@inexture/dropzone": "workspace:22.0.1",
+    "@inexture/core": "workspace:*",
+    "@inexture/dates": "workspace:*",
+    "@inexture/dropzone": "workspace:*",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,10 +45,10 @@ importers:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -91,10 +91,10 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       recharts:
         specifier: ^3.1.1
@@ -146,10 +146,10 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       react-icons:
         specifier: 5.5.0
@@ -186,10 +186,10 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -229,10 +229,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -272,10 +272,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -315,10 +315,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -358,10 +358,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -518,10 +518,10 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -561,10 +561,10 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       react:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0
       react-dom:
-        specifier: '*'
+        specifier: '>=17.0.0'
         version: 19.1.0(react@19.1.0)
       react-dropzone-esm:
         specifier: ^15.2.0


### PR DESCRIPTION
## Summary
- use `workspace:*` for all `@inexture/*` packages in devDependencies
- update pnpm lockfile

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689214851f7c83248071817043213865