### PR TITLE
chore: loosen peer dependency versions

### DIFF
--- a/.changeset/revert-peer-deps-star.md
+++ b/.changeset/revert-peer-deps-star.md
@@ -1,0 +1,14 @@
+---
+"@inexture/core": patch
+"@inexture/carousel": patch
+"@inexture/charts": patch
+"@inexture/dates": patch
+"@inexture/dropzone": patch
+"@inexture/highlight": patch
+"@inexture/modals": patch
+"@inexture/spotlight": patch
+"@inexture/tiptap": patch
+"@inexture/form": patch
+---
+
+Revert peer dependency versions back to "*".

--- a/libs/@core/carousel/package.json
+++ b/libs/@core/carousel/package.json
@@ -48,8 +48,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/charts/package.json
+++ b/libs/@core/charts/package.json
@@ -49,8 +49,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/core/package.json
+++ b/libs/@core/core/package.json
@@ -79,7 +79,7 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/dates/package.json
+++ b/libs/@core/dates/package.json
@@ -48,8 +48,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/dropzone/package.json
+++ b/libs/@core/dropzone/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/highlight/package.json
+++ b/libs/@core/highlight/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/modals/package.json
+++ b/libs/@core/modals/package.json
@@ -41,8 +41,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/spotlight/package.json
+++ b/libs/@core/spotlight/package.json
@@ -47,8 +47,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@core/tiptap/package.json
+++ b/libs/@core/tiptap/package.json
@@ -92,8 +92,8 @@
     "shx": "^0.4.0"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/libs/@library/form/package.json
+++ b/libs/@library/form/package.json
@@ -55,10 +55,10 @@
     "zod": "^4.0.14"
   },
   "peerDependencies": {
-    "@inexture/core": "20.0.1",
-    "@inexture/dates": "22.0.1",
-    "@inexture/dropzone": "22.0.1",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0"
+    "@inexture/core": "*",
+    "@inexture/dates": "*",
+    "@inexture/dropzone": "*",
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,10 +45,10 @@ importers:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -91,10 +91,10 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       recharts:
         specifier: ^3.1.1
@@ -146,10 +146,10 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       react-icons:
         specifier: 5.5.0
@@ -186,10 +186,10 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -229,10 +229,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -272,10 +272,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -315,10 +315,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -358,10 +358,10 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3(@mantine/core@8.2.3(@mantine/hooks@8.2.3(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.2.3(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -518,10 +518,10 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       shx:
         specifier: ^0.4.0
@@ -561,10 +561,10 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       react:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0
       react-dom:
-        specifier: '>=17.0.0'
+        specifier: '*'
         version: 19.1.0(react@19.1.0)
       react-dropzone-esm:
         specifier: ^15.2.0


### PR DESCRIPTION
## Summary
- reset React, React DOM, and internal packages to wildcard peer deps
- record patch release for affected packages

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892179fe8048324bec255b6929234e1